### PR TITLE
Make error message easier to read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,10 @@ impl Display for Error {
                 write!(f, "the '{}' option doesn't have an associated value", key)
             }
             Error::Utf8ArgumentParsingFailed { value, cause } => {
-                write!(f, "failed to parse '{}' cause {}", value, cause)
+                write!(f, "failed to parse '{}': {}", value, cause)
             }
             Error::ArgumentParsingFailed { cause } => {
-                write!(f, "failed to parse a binary argument cause {}", cause)
+                write!(f, "failed to parse a binary argument: {}", cause)
             }
             Error::UnusedArgsLeft(args) => {
                 // Do not use `args.join()`, because it adds 1.2KiB.


### PR DESCRIPTION
Before, it looked like they were part of the same phrase: 'binary argument cause'. IMO the new output is easier to read at a glance.