### PR TITLE
Added example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ If you think that this library doesn't support some feature, it's probably inten
   If `eq-separator` is disabled, then `-K=value` gives an error instead of returning `"=value"`.<br/>
   The optional space is only applicable for short keys because `--keyvalue` would be ambiguous.
 
+### Examples
+
+If you clone this repository, you can try out some examples of programs that use `pico-args`.
+
+```sh
+cargo run --example app -- --help
+cargo run --example rat -- --help
+cargo run --example dash_dash -- --help
+```
+
+If you have minimal examples of your own, feel free to create a pull request.
+Also feel free to check out the examples in the `examples` folder to see how 
+you can use `pico-args` in your project.
+
 ### Alternatives
 
 The core idea of `pico-args` is to provide some "sugar" for arguments parsing without

--- a/examples/rat.rs
+++ b/examples/rat.rs
@@ -1,0 +1,73 @@
+// Rat - A simple and practical example of pico_args
+use pico_args::{Arguments, Error};
+use std::fs;
+
+// Help message
+const HELP: &str = "\
+rat - A program to read and display files
+
+Usage:
+    rat [options] FILE
+
+Options:
+    -h, --help     | Display this help message
+    -l, --lines    | Display line numbers
+
+Examples:
+    rat note12.txt | Displays the file note12.txt without line numbers
+    rat -l test.py | Displays the file test.py with line numbers
+";
+
+fn main() {
+    // Read arguments and handle any errors
+    if let Err(error) = do_args() {
+        println!("Error: {}", error);
+    }
+}
+
+fn do_args() -> Result<(), Error> {
+    // Create argument reader from user provided arguments
+    let mut args = Arguments::from_env();
+    // NOTE: It's best practice to handle flags before everything else
+    // Check for a help flag (and exit if it's there)
+    if args.contains(["-h", "--help"]) {
+        print!("{}", HELP);
+        std::process::exit(0);
+    }
+    // Check for the presence of the --lines flag
+    let line_numbers = args.contains(["-l", "--lines"]);
+    // Read file and print it
+    let path = args.free_from_str::<String>()?;
+    if let Ok(contents) = fs::read_to_string(&path) {
+        // File was read sucessfully, print it
+        do_print(contents, line_numbers);
+    } else {
+        // File failed to open
+        println!("Error: failed to open file `{}`", path);
+    }
+    // Gather remaining arguments and warn the user about them
+    let remaining = args.finish();
+    if !remaining.is_empty() {
+        eprintln!("Warning: unused arguments: {:?}.", remaining)
+    }
+    // Exit successfully
+    Ok(())
+}
+
+fn do_print(contents: String, line_numbers: bool) {
+    // Print out contents
+    let mut lines = contents.split('\n');
+    // Remove last \n
+    lines.next_back();
+    // Check for lines flag
+    if line_numbers {
+        // User provided the --lines flag
+        for (number, line) in lines.enumerate() {
+            // Print out lines
+            println!("{: <5}| {}", number, line);
+        }
+    } else {
+        // User didn't provide the --lines flag
+        println!("{}", lines.collect::<Vec<_>>().join("\n"));
+    }
+}


### PR DESCRIPTION
Hello there,

I just discovered `pico-args` earlier today, and I thought I'd contribute a bit.
I added an example of `pico-args` to the examples folder.
I also added a section to the readme.

Really great to see a simple yet entirely usable minimal alternative to `clap`, which holds a large monopoly.

Me and a few other people who were trying the library struggled with learning how to use it as the documentation is a bit confusing. In the future, I might create a PR which improves upon the existing documentation, if that's all OK.

Let me know if there is anything that needs changing / adding / removing to this PR or feel free to do it yourself.

Thanks :)