### PR TITLE
Do not search for combined flags in long options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,13 +173,13 @@ impl Arguments {
             true
         } else {
             #[cfg(feature = "combined-flags")]
-            // Combined flags only work of the short flag is a single character
+            // Combined flags only work if the short flag is a single character
             {
                 if keys.first().len() == 2 {
                     let short_flag = &keys.first()[1..2];
                     for (n, item) in self.0.iter().enumerate() {
                         if let Some(s) = item.to_str() {
-                            if s.starts_with('-') && s.contains(short_flag) {
+                            if s.starts_with('-') && !s.starts_with("--") && s.contains(short_flag) {
                                 if s.len() == 2 {
                                     // last flag
                                     self.0.remove(n);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -230,6 +230,21 @@ fn combined_flags_leftover() {
     assert_eq!(args.finish(), vec![OsString::from("-b")]);
 }
 
+#[test]
+fn long_flag_with_character_from_short_flag() {
+    let mut args = Arguments::from_vec(to_vec(&["--version"]));
+    assert!(!args.contains("-s"));
+    assert!(args.contains("--version"));
+}
+
+#[cfg(feature = "combined-flags")]
+#[test]
+fn combined_long_flag_with_character_from_short_flag() {
+    let mut args = Arguments::from_vec(to_vec(&["--version"]));
+    assert!(!args.contains("-s"));
+    assert!(args.contains("--version"));
+}
+
 #[cfg(feature = "short-space-opt")]
 #[test]
 fn space_option_01() {


### PR DESCRIPTION
This PR fixes a bug related to the feature `combined-flags`.
If the feature is enabled, searching for a short flag will wrongly inspect long options for the presence of a character, and it will remove it if present.

So if you search for the flag `-s` and the user provided `--version`, the latter will become `--verion`.