### PR TITLE
Support parsing non- UTF-8 values from "="-separated arguments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,38 +2,35 @@ name: Rust
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.32.0
-          - stable
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - uses: taiki-e/install-action@cargo-hack
 
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        override: true
+    - run: rustup update stable && rustup default stable
+    - run: cargo hack clippy --all-targets --feature-powerset
+    - run: cargo hack test --feature-powerset
+    - run: cargo hack test --feature-powerset --rust-version
 
-    - name: Test with default features
-      run: cargo test
-
-    - name: Test without default features
-      run: cargo test --no-default-features
-
-    - name: Test with short-space-opt
-      run: cargo test --no-default-features --features short-space-opt
-
-    - name: Test with combined-flags
-      run: cargo test --no-default-features --features combined-flags
-
-    - name: Test with all features
-      run: cargo test --all-features
+    - run: rustup update nightly && rustup default nightly
+    - run: rustup component add miri
+    - run: cargo +nightly miri setup
+    - run: cargo +nightly miri test --all-features
+    - run: cargo +nightly miri setup --target=x86_64-pc-windows-msvc
+    - run: cargo +nightly miri test --all-features --target=x86_64-pc-windows-msvc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "pico-args"
 version = "0.5.0"
 authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
-edition = "2018"
+rust-version = "1.74"
+edition = "2021"
 keywords = ["args", "cli"]
 license = "MIT"
 description = "An ultra simple CLI arguments parser."

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -565,8 +565,8 @@ fn opt_free_from_fn_05() {
 
 #[test]
 fn opt_free_from_fn_06() {
-    let mut args = Arguments::from_vec(to_vec(&["-3.14"]));
-    assert_eq!(args.opt_free_from_fn(f32::from_str).unwrap(), Some(-3.14f32));
+    let mut args = Arguments::from_vec(to_vec(&["-2.9933"]));
+    assert_eq!(args.opt_free_from_fn(f32::from_str).unwrap(), Some(-2.9933_f32));
 }
 
 #[test]


### PR DESCRIPTION
Hey! I'm a huge fan of this library -- the minimalism is definitely refreshing. So I was a bit disappointed when I tried parsing a `PathBuf` with `value_from_os_str()` + `feature = "eq-separator"`... and discovered that it didn't work.

Fortunately, some new APIs were added in rust 1.74 that make this possible: [`OsStr::as_encoded_bytes`] and [`OsStr::from_encoded_bytes_unchecked`].

To support non-UTF-8 arg-value parsing, I added two new primitives: `os_str_strip_prefix` and `os_str_strip_suffix`. These act just like `str::strip_prefix` and `str::strip_suffix` respectively but work on `&OsStr` across all platforms. They both use [`OsStr::from_encoded_bytes_unchecked`] under-the-hood, which is unsafe. Quoting the safety requirements from the docs:

> Due to the encoding being self-synchronizing, the bytes from [`OsStr::as_encoded_bytes`] can be split either immediately before or immediately after any valid non-empty UTF-8 substring.

Since we're stripping valid UTF-8 substrings from the front or back of a `text: &OsStr`, this is safe. You can see similar activity going on inside `Path` and `PathBuf` in std.

This diff also delays any `&OsStr` -> `&str` conversion until the last moment, when we
actually to expose a `&str` to the caller.

Of course, one downside here is that we would have to raise the MSRV to 1.74. The `#![forbid(unsafe)]` is also gone : (. Might be a deal breaker, up to you.

Finally, here's a very scientific table showing the binary size for `cargo build --release --example=app --target=x86_64-unknown-linux-gnu --features=...`:

```
branch     feature            size (B)
           
master     default            453,600
           eq-separator       453,912
           short-space-opt    453,760
           combined-flags     453,816

PR         default            453,600
           eq-separator       453,752
           short-space-opt    453,760
           combined-flags     453,816
```

One upside is that the binary size for `eq-separator` actually went down.

[`OsStr::as_encoded_bytes`]: https://doc.rust-lang.org/stable/std/ffi/os_str/struct.OsStr.html#method.as_encoded_bytes
[`OsStr::from_encoded_bytes_unchecked`]: https://doc.rust-lang.org/stable/std/ffi/struct.OsStr.html#method.from_encoded_bytes_unchecked