### PR TITLE
Fix args_os panic on webassembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Prevent panic in `Argument::from_env()` on `wasm32` due to `args_os`
+  returning zero arguments instead of one.
+  Thanks to [@cwfitzgerald](https://github.com/cwfitzgerald)
 
 ## [0.5.0] - 2022-06-04
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,12 +119,15 @@ impl Arguments {
 
     /// Creates a parser from [`env::args_os`].
     ///
-    /// The executable path will be removed.
+    /// The first argument (typically the executable path) will be ignored
+    /// if it is present.
     ///
     /// [`env::args_os`]: https://doc.rust-lang.org/stable/std/env/fn.args_os.html
     pub fn from_env() -> Self {
-        let mut args: Vec<_> = std::env::args_os().collect();
-        args.remove(0);
+        // On platforms without a well defined environment, like webassembly,
+        // args_os always returns an empty iterator. Skip handles this gracefully,
+        // resulting in an empty Arguments list.
+        let args: Vec<_> = std::env::args_os().skip(1).collect();
         Arguments(args)
     }
 


### PR DESCRIPTION
Small fix for handling webassembly and other strange platforms which give an zero-length `args` list.

Thanks for the library!